### PR TITLE
Implement a better way to withdraw from Plasma.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Implements a Solidity contract to manage Plasma side-chain on Ethereum.
 $ npm install
 ```
 
+
 ## Run test cases:
 
 ```
@@ -17,10 +18,16 @@ $ ./ganache-cli
 $ truffle test
 ```
 
+## Details
+
+The implementation is based on UTXO model. It allows depositing, submitting blocks and withdrawing.
+The current implementation is not designed to withstand double-spends caused by fraudulent operators.
+Operators are selected by the contract creator. PoS consensus mechanism is coming in the future.
+
 ## TODO
 
 - Implement a way to challenge withdrawals;
-- Implement consensus between operators;
+- Implement a consensus layer;
 - Optimize the code in order to spend less gas;
 - Implement a better serialization mechanism.
 

--- a/contracts/Plasma.sol
+++ b/contracts/Plasma.sol
@@ -140,8 +140,8 @@ contract Plasma is Ownable {
         bytes _transactionBytes, bytes _proof,
         uint outputIndex,
         uint _exitHeaderNumber,
-        bytes _exitTransactionBytes, bytes _exitProof) public returns (bool success) {
-
+        bytes _exitTransactionBytes, bytes _exitProof
+    ) public returns (bool success) {
         // check if exitTx exists
         Header storage header = headers[_exitHeaderNumber];
         Transaction memory exitTransaction = decodeTransaction(_exitTransactionBytes);

--- a/test/TestPlasma.js
+++ b/test/TestPlasma.js
@@ -241,8 +241,15 @@ contract('Plasma', async ([owner]) => {
     // withdraw part
     const merkleTree = new MerkleTree([spendTransaction1.tid(), spendTransaction2.tid()]);
 
-    const event1 = (await plasma.withdraw(headers.length - 2, spendTransaction1.toRLPHex(), merkleTree.getHexProof(spendTransaction1.tid()), 0,
-      headers.length - 1, exitTransaction1.toRLPHex(), exitMerkleTree.getHexProof(exitTransaction1.tid()))).logs.find(x => x.event === 'WithdrawEvent');
+    const event1 = (await plasma
+      .withdraw(headers.length - 2,
+        spendTransaction1.toRLPHex(),
+        merkleTree.getHexProof(spendTransaction1.tid()),
+        0,
+        headers.length - 1,
+        exitTransaction1.toRLPHex(),
+        exitMerkleTree.getHexProof(exitTransaction1.tid())))
+      .logs.find(log => log.event === 'WithdrawEvent');
 
     assert.equal(event1.args._to, privToAddr(spendPriv));
     assert.equal(event1.args._amount, 1000);


### PR DESCRIPTION
The user provides a proof that plasma coins have been destroyed (sent to ZERO address).
This prevents withdrawing UTXO multiple times since there's no way to spend the coins.